### PR TITLE
Fix code scanning alert no. 76: Type confusion through parameter tampering

### DIFF
--- a/lib/insecurity.ts
+++ b/lib/insecurity.ts
@@ -138,7 +138,10 @@ export const redirectAllowlist = new Set([
   'http://leanpub.com/juice-shop'
 ])
 
-export const isRedirectAllowed = (url: string) => {
+export const isRedirectAllowed = (url: string | string[]) => {
+  if (Array.isArray(url)) {
+    url = url[0]
+  }
   let allowed = false
   for (const allowedUrl of redirectAllowlist) {
     allowed = allowed || url.includes(allowedUrl) // vuln-code-snippet vuln-line redirectChallenge

--- a/routes/redirect.ts
+++ b/routes/redirect.ts
@@ -12,8 +12,8 @@ const challenges = require('../data/datacache').challenges
 
 module.exports = function performRedirect () {
   return ({ query }: Request, res: Response, next: NextFunction) => {
-    const toUrl = query.to
-    if (security.isRedirectAllowed(toUrl)) {
+    const toUrl = Array.isArray(query.to) ? query.to[0] : query.to
+    if (security.isRedirectAllowed(toUrl as string)) {
       challengeUtils.solveIf(challenges.redirectCryptoCurrencyChallenge, () => { return toUrl === 'https://explorer.dash.org/address/Xr556RzuwX6hg5EGpkybbv5RanJoZN17kW' || toUrl === 'https://blockchain.info/address/1AbKfgvw9psQ41NbLi8kufDQTezwG8DRZm' || toUrl === 'https://etherscan.io/address/0x0f933ab9fcaaa782d0279c300d73750e1311eae6' })
       challengeUtils.solveIf(challenges.redirectChallenge, () => { return isUnintendedRedirect(toUrl as string) })
       res.redirect(toUrl as string)


### PR DESCRIPTION
Fixes [https://github.com/vs-code-scanning/juice-shop-default/security/code-scanning/76](https://github.com/vs-code-scanning/juice-shop-default/security/code-scanning/76)

To fix the problem, we need to ensure that the `toUrl` parameter is always treated as a string before performing any operations on it. This can be done by checking the type of `toUrl` and converting it to a string if necessary. This change should be made in the `performRedirect` function in `routes/redirect.ts` and the `isRedirectAllowed` function in `lib/insecurity.ts`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
